### PR TITLE
Enforce default role for public registrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "dev": "nodemon server.js",
     "start": "node server.js"
   },

--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -1,7 +1,11 @@
 // src/controllers/auth.controller.js
 import { getCollection } from "../db/client.js";
 import { hashPassword, verifyPassword } from "../utils/password.js";
-import { loginSchema, registerSchema } from "../validators/users.schema.js";
+import {
+  DEFAULT_ROLE,
+  loginSchema,
+  publicRegisterSchema,
+} from "../validators/users.schema.js";
 import {
   forgotSchema,
   resetSchema,
@@ -15,7 +19,7 @@ const now = () => new Date();
 
 /** REGISTER: crée user non vérifié + log lien vérification */
 export async function register(req, res) {
-  const { error, value } = registerSchema.validate(req.body, {
+  const { error, value } = publicRegisterSchema.validate(req.body, {
     abortEarly: false,
     stripUnknown: true,
   });
@@ -31,7 +35,7 @@ export async function register(req, res) {
     const doc = {
       email,
       password_hash: await hashPassword(value.password),
-      role: value.role,
+      role: DEFAULT_ROLE,
       display_name: value.display_name ?? null,
       email_verified_at: null, // 👈 non vérifié à la création
       created_at: now(),

--- a/src/validators/users.schema.js
+++ b/src/validators/users.schema.js
@@ -1,5 +1,7 @@
 import Joi from "joi";
 
+export const DEFAULT_ROLE = "visiteur";
+
 // Payloads
 export const registerSchema = Joi.object({
   email: Joi.string().email().required(),
@@ -7,7 +9,13 @@ export const registerSchema = Joi.object({
   display_name: Joi.string().allow("", null),
   role: Joi.string()
     .valid("MasterOfUnivers", "superadmin", "officier", "agent", "visiteur")
-    .default("visiteur"),
+    .default(DEFAULT_ROLE),
+});
+
+export const publicRegisterSchema = Joi.object({
+  email: Joi.string().email().required(),
+  password: Joi.string().min(8).required(),
+  display_name: Joi.string().allow("", null),
 });
 
 export const loginSchema = Joi.object({

--- a/tests/public-register-schema.test.js
+++ b/tests/public-register-schema.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_ROLE,
+  publicRegisterSchema,
+} from "../src/validators/users.schema.js";
+
+const basePayload = {
+  email: "new-user@example.com",
+  password: "password123",
+  display_name: "New User",
+};
+
+test("public registration strips any provided role", () => {
+  const { error, value } = publicRegisterSchema.validate(
+    { ...basePayload, role: "superadmin" },
+    { abortEarly: false, stripUnknown: true }
+  );
+
+  assert.ifError(error);
+  assert.equal(value.role, undefined);
+});
+
+test("default role constant is visiteur", () => {
+  assert.equal(DEFAULT_ROLE, "visiteur");
+});


### PR DESCRIPTION
## Summary
- add a dedicated public registration schema and shared default role constant
- update auth registration flow to force the visiteur role and ignore user-provided roles
- add node-based tests confirming the role is stripped and wire npm test to node --test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68deb5e65b6c8320b589e84612e9cfa4